### PR TITLE
Persist globals across front-end page changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ app.use(sharedContext({
 	// The variable which is set on `res.locals`
 	// localsVar: 'context',
 
-	// Set globals that are included in every request
+	// Set globals that are included in every request,
+	// even front-end page changes with a FE router like nighthawk
+	// globalsVar: '__$globals',
 	// globals: {}
 }));
 

--- a/index.js
+++ b/index.js
@@ -1,42 +1,79 @@
 var setPrototypeOf = require('setprototypeof');
 var escape = require('recursive-escape');
 var unescape = require('recursive-unescape');
+var _win = typeof window !== 'undefined' && window;
 
-module.exports = function setupSharedContext (opts) {
-	// Setup optional configuration
-	opts = opts || {};
-	opts.browserVar = opts.browserVar || '__context';
-	opts.localsVar = opts.localsVar || 'context';
-
-	// Override toJSON so the data is escaped correctly for
-	// output in html, usually a script tag:
-	// <script>window.__context = <%- JSON.stringify(context) %></script>
-	var escapeProto = {
-		toJSON: function () {
-			return escape(this);
-		}
-	};
-
-	// Globals should extend from our escape json proto
-	if (opts.globals) {
-		setPrototypeOf(opts.globals, escapeProto);
+// Override toJSON so the data is escaped correctly for
+// output in html, usually a script tag:
+// <script>window.__context = <%- JSON.stringify(context) %></script>
+var escapeProto = {
+	toJSON: function () {
+		return escape(this);
 	}
+};
+
+module.exports = function setupSharedContext (_opts) {
+	// Setup optional configuration
+	var opts = _opts || {};
+
+	// Allow overriding the window reference, mostly for testing
+	var _window = opts.window || _win;
+
+	// Configurable variable names
+	var browserVar = opts.browserVar || '__context';
+	var localsVar = opts.localsVar || 'context';
+	var globalsVar = opts.globalsVar || '__$globals';
+
+	// Globals should inherit from our escape json proto
+	var globals;
+	if (opts.globals) {
+		globals = setPrototypeOf(opts.globals, escapeProto);
+	} else {
+		globals = Object.create(escapeProto);
+	}
+
+	// Keep global keys
+	var globalKeys = Object.keys(globals);
 
 	return function sharedContext (req, res, next) {
 		// This is an isomorphic middleware, so this first step
 		// is what is run in the browser to load the context
 		// from what the backend passed to us
-		if (typeof window !== 'undefined' && window[opts.browserVar]) {
-			res.locals[opts.localsVar] = unescape(window[opts.browserVar]);
-			window[opts.browserVar] = null;
-			if (opts.globals) {
-				setPrototypeOf(res.locals[opts.localsVar], opts.globals);
+		if (_window && _window[browserVar]) {
+			// Load up and unescape the values from the server, nulling out after
+			res.locals[localsVar] = unescape(_window[browserVar]);
+			_window[browserVar] = null;
+
+			// Store/load in globals
+			if (Array.isArray(res.locals[localsVar][globalsVar])) {
+				res.locals[localsVar][globalsVar].forEach(function (key) {
+					// Keep value
+					globals[key] = globals[key] || res.locals[localsVar][key];
+
+					// Ensure its in the keys array
+					if (globalKeys.indexOf(key) === -1) {
+						globalKeys.push(key);
+					}
+				});
+
+				// Delete globals var once loaded
+				delete res.locals[localsVar][globalsVar];
 			}
+
+			// Setup our new object to inherit the globals
+			setPrototypeOf(res.locals[localsVar], globals);
 		} else {
 			// On the backend or after the initial
 			// page load in a single page app,
 			// we just initialize an empty object
-			res.locals[opts.localsVar] = Object.create(opts.globals || escapeProto);
+			res.locals[localsVar] = Object.create(globals);
+
+			// Track which keys should be persisted through route changes as globals,
+			// non-configurable/modifiable but enumerable
+			Object.defineProperty(res.locals[localsVar], globalsVar, {
+				value: globalKeys,
+				enumerable: true
+			});
 		}
 
 		// Continue on good sir..

--- a/test/index.js
+++ b/test/index.js
@@ -29,37 +29,30 @@ describe('Shared Context', function () {
 	});
 
 	it('should load values from the window in the browser', function (done) {
-		// Mock out window
-		var _win = global.window;
-		global.window = {
-			__context: { foo: 'bar' }
-		};
-
-		var sc = sharedContext();
+		var sc = sharedContext({
+			window: {
+				__context: { foo: 'bar' }
+			}
+		});
 		var res = {locals: {}};
 		sc({}, res, function () {
 			assert(res.locals.context);
 			assert.equal(res.locals.context.foo, 'bar');
-			global.window = _win;
 			done();
 		});
 	});
 
 	it('should accept browserVar option', function (done) {
-		// Mock out window
-		var _win = global.window;
-		global.window = {
-			__customVar: { foo: 'bar' }
-		};
-
 		var sc = sharedContext({
-			browserVar: '__customVar'
+			browserVar: '__customVar',
+			window: {
+				__customVar: { foo: 'bar' }
+			}
 		});
 		var res = {locals: {}};
 		sc({}, res, function () {
 			assert(res.locals.context);
 			assert.equal(res.locals.context.foo, 'bar');
-			global.window = _win;
 			done();
 		});
 	});


### PR DESCRIPTION
```
app.use(sharedContext({
  globals: {
    staticPath: 'https://...',
    user: null
  }
}));
```

After loading up either `staticPath` or `user` with a value, it will persist across front-end page changes as well as from the back to front end on the first page load.  Adds a key of `__$globalVars` to the context, but cleans up after itself.